### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
-| `-e UMASK_SET=<022>` | Umask setting - [explaination](https://askubuntu.com/questions/44542/what-is-umask-and-how-does-it-work) |
+| `-e UMASK_SET=<022>` | Umask setting - [explanation](https://askubuntu.com/questions/44542/what-is-umask-and-how-does-it-work) |
 | `-v /config` | Configuration files. |
 | `-v /data1` | Data1 |
 | `-v /data2` | Data2 |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -19,7 +19,7 @@ param_container_name: "{{ project_name }}"
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
-  - { env_var: "UMASK_SET", env_value: "<022>", desc: "Umask setting - [explaination](https://askubuntu.com/questions/44542/what-is-umask-and-how-does-it-work)" }
+  - { env_var: "UMASK_SET", env_value: "<022>", desc: "Umask setting - [explanation](https://askubuntu.com/questions/44542/what-is-umask-and-how-does-it-work)" }
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Configuration files." }


### PR DESCRIPTION
Fixed a small typo in two places in the documentation ('explaination' should be 'explanation').