### PR TITLE
workaround to keep pipeline building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ echo "**** fetch source code ****" && \
 	/tmp/sync --strip-components=1 && \
  echo "**** compile syncthing  ****" && \
  cd /tmp/sync && \
+ rm -f go.sum && \
+ go clean -modcache && \
  CGO_ENABLED=0 go run build.go \
 	-no-upgrade \
 	-version=${SYNCTHING_RELEASE} \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -29,6 +29,8 @@ echo "**** fetch source code ****" && \
 	/tmp/sync --strip-components=1 && \
  echo "**** compile syncthing  ****" && \
  cd /tmp/sync && \
+ rm -f go.sum && \
+ go clean -modcache && \
  CGO_ENABLED=0 go run build.go \
 	-no-upgrade \
 	-version=${SYNCTHING_RELEASE} \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -29,6 +29,8 @@ echo "**** fetch source code ****" && \
 	/tmp/sync --strip-components=1 && \
  echo "**** compile syncthing  ****" && \
  cd /tmp/sync && \
+ rm -f go.sum && \
+ go clean -modcache && \
  CGO_ENABLED=0 go run build.go \
 	-no-upgrade \
 	-version=${SYNCTHING_RELEASE} \


### PR DESCRIPTION
There are slight security implications with not using the checksums from upstream, but we still control the env, as long as a plugin maker does not go full rogue this should be fine. 