### PR TITLE
Add support for env var STGUIADDRESS and use it instead of a hardcoded value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ LABEL maintainer="thelamer"
 
 # environment settings
 ENV HOME="/config"
+ENV STGUIADDRESS=0.0.0.0:8384
 
 RUN \
  echo "**** create var lib folder ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -46,6 +46,7 @@ LABEL maintainer="thelamer"
 
 # environment settings
 ENV HOME="/config"
+ENV STGUIADDRESS=0.0.0.0:8384
 
 RUN \
  echo "**** create var lib folder ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -46,6 +46,7 @@ LABEL maintainer="thelamer"
 
 # environment settings
 ENV HOME="/config"
+ENV STGUIADDRESS=0.0.0.0:8384
 
 RUN \
  echo "**** create var lib folder ****" && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -22,6 +22,8 @@ param_hostname_desc: "Optionally the hostname can be defined."
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
+opt_param_env_vars:
+  - { env_var: "STGUIADDRESS", env_value: "0.0.0.0:8384", desc: "The GUI listen address (internal)." }
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Configuration files." }
@@ -42,6 +44,7 @@ app_setup_nginx_reverse_proxy_block: ""
 # changelog
 
 changelogs:
+  - { date: "09.03.21:", desc: "Use `STGUIADDRESS` instead of a hardcoded value." }
   - { date: "29.01.21:", desc: "Deprecate `UMASK_SET` in favor of UMASK in baseimage, see above for more information." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "15.09.20:", desc: "Use go from alpine edge repo to compile. Remove duplicate UMASK env var. Add hostname setting." }

--- a/root/etc/services.d/syncthing/run
+++ b/root/etc/services.d/syncthing/run
@@ -7,5 +7,4 @@ fi
 
 exec \
 	s6-setuidgid abc syncthing \
-	-home=/config -no-browser -no-restart \
-	--gui-address="0.0.0.0:8384"
+	-home=/config -no-browser -no-restart


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-syncthing/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Using the environment variable is more flexible than a hardcoded value
in the run script. This is needed when running multiple instances on a
single host using host network mode, which itself is useful for local
broadcasting and discovery.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
There's no way with current container to change internal port for the GUI. Which is a problem if network in host mode is needed and more than one container should be run on the same host. Using the env.variable allows us to specify different ports for different containers in host network mode.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built an image from the Dockerfile and used it to create and run 2 containers simultaneously on the same host. Both Syncthing instances were successfully reachable via their GUI on assigned ports and local discovery was functional and the instances were able to connect directly with other Syncthing instances on the local network.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
