### PR TITLE
Add port mapping for 22000/udp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,5 +57,5 @@ COPY --from=buildstage /tmp/sync/syncthing /usr/bin/
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8384 22000 21027/UDP
+EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
 VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -57,5 +57,5 @@ COPY --from=buildstage /tmp/sync/syncthing /usr/bin/
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8384 22000 21027/UDP
+EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
 VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -57,5 +57,5 @@ COPY --from=buildstage /tmp/sync/syncthing /usr/bin/
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8384 22000 21027/UDP
+EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
 VOLUME /config

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,7 +30,8 @@ param_volumes:
 param_usage_include_ports: true
 param_ports:
   - { external_port: "8384", internal_port: "8384", port_desc: "Application WebUI" }
-  - { external_port: "22000", internal_port: "22000", port_desc: "Listening port" }
+  - { external_port: "22000", internal_port: "22000/tcp", port_desc: "Listening port (TCP)" }
+  - { external_port: "22000", internal_port: "22000/udp", port_desc: "Listening port (UDP)" }
   - { external_port: "21027", internal_port: "21027/udp", port_desc: "Protocol discovery" }
 
 # application setup block
@@ -42,6 +43,7 @@ app_setup_nginx_reverse_proxy_block: ""
 # changelog
 
 changelogs:
+  - { date: "03.05.21:", desc: "Add port mapping for 22000/udp." }
   - { date: "29.01.21:", desc: "Deprecate `UMASK_SET` in favor of UMASK in baseimage, see above for more information." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "15.09.20:", desc: "Use go from alpine edge repo to compile. Remove duplicate UMASK env var. Add hostname setting." }


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-syncthing/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

closes #47 

Adds an additional port mapping for 22000/udp to allow incoming QUIC protocol connections.
