### PR TITLE
Raise UDP buffer size

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,6 +32,8 @@ param_ports:
   - { external_port: "8384", internal_port: "8384", port_desc: "Application WebUI" }
   - { external_port: "22000", internal_port: "22000", port_desc: "Listening port" }
   - { external_port: "21027", internal_port: "21027/udp", port_desc: "Protocol discovery" }
+custom_params:
+  - { name: "sysctl", name_compose: "sysctls", value: ["net.core.rmem_max=2097152"], desc: "Raise maximum UDP buffer size.", array: "true" }
 
 # application setup block
 app_setup_block_enabled: true
@@ -42,6 +44,7 @@ app_setup_nginx_reverse_proxy_block: ""
 # changelog
 
 changelogs:
+  - { date: "03.05.21:", desc: "Raise maximum UDP buffer size." }
   - { date: "29.01.21:", desc: "Deprecate `UMASK_SET` in favor of UMASK in baseimage, see above for more information." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "15.09.20:", desc: "Use go from alpine edge repo to compile. Remove duplicate UMASK env var. Add hostname setting." }


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-syncthing/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------


## Description:

Change readme to raise maximum UDP read buffer size similar to upstream: https://github.com/syncthing/syncthing/blob/main/README-Docker.md#example-usage

## Benefits of this PR and context:
Better performance for QUICconnections.
