### PR TITLE
Revert Raise UDP buffer size

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -33,8 +33,6 @@ param_ports:
   - { external_port: "22000", internal_port: "22000/tcp", port_desc: "Listening port (TCP)" }
   - { external_port: "22000", internal_port: "22000/udp", port_desc: "Listening port (UDP)" }
   - { external_port: "21027", internal_port: "21027/udp", port_desc: "Protocol discovery" }
-custom_params:
-  - { name: "sysctl", name_compose: "sysctls", value: ["net.core.rmem_max=2097152"], desc: "Raise maximum UDP buffer size.", array: "true" }
 
 # application setup block
 app_setup_block_enabled: true
@@ -45,6 +43,7 @@ app_setup_nginx_reverse_proxy_block: ""
 # changelog
 
 changelogs:
+  - { date: "12.05.21:", desc: "Remove sysctl parameter again" }
   - { date: "03.05.21:", desc: "Raise maximum UDP buffer size." }
   - { date: "03.05.21:", desc: "Add port mapping for 22000/udp." }
   - { date: "29.01.21:", desc: "Deprecate `UMASK_SET` in favor of UMASK in baseimage, see above for more information." }


### PR DESCRIPTION
Reverts linuxserver/docker-syncthing#49

Fixes #50 

Contrary to their documentation docker is not able to properly handle this: https://github.com/moby/moby/issues/30778