### PR TITLE
Separate data and config directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # environment settings
-ENV HOME="/config"
+ENV HOME="/data"
 
 RUN \
   echo "**** create var lib folder ****" && \
@@ -57,3 +57,4 @@ COPY root/ /
 # ports and volumes
 EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
 VOLUME /config
+VOLUME /data

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -43,7 +43,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # environment settings
-ENV HOME="/config"
+ENV HOME="/data"
 
 RUN \
   echo "**** create var lib folder ****" && \
@@ -57,3 +57,4 @@ COPY root/ /
 # ports and volumes
 EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
 VOLUME /config
+VOLUME /data

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -22,8 +22,7 @@ param_env_vars:
 param_usage_include_vols: true
 param_volumes:
   - {vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Configuration files."}
-  - {vol_path: "/data1", vol_host_path: "/path/to/data1", desc: "Data1"}
-  - {vol_path: "/data2", vol_host_path: "/path/to/data2", desc: "Data2"}
+  - {vol_path: "/data", vol_host_path: "/path/to/data", desc: "Dedicated data directory"}
 param_usage_include_ports: true
 param_ports:
   - {external_port: "8384", internal_port: "8384", port_desc: "Application WebUI"}
@@ -35,6 +34,7 @@ app_setup_block_enabled: true
 app_setup_block: "**Note: ** The Syncthing devs highly suggest setting a password for this container as it listens on 0.0.0.0. To do this go to `Actions -> Settings -> set user/password` for the webUI."
 # changelog
 changelogs:
+  - {date: "10.12.23:", desc: "Add a dedicated data directory volume"}
   - {date: "05.09.23:", desc: "Rebase to Alpine 3.18."}
   - {date: "01.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "13.02.23:", desc: "Rebase to Alpine 3.17, migrate to s6v3."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
@@ -3,6 +3,6 @@
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8384" \
-        s6-setuidgid abc syncthing \
-        -home=/config -no-browser -no-restart \
-        --gui-address="0.0.0.0:8384"
+        s6-setuidgid abc syncthing --config=/config --data=/data \
+	--no-browser --no-restart --gui-address="0.0.0.0:8384" \
+        --no-default-folder


### PR DESCRIPTION
Add a new directory /data to put the shares in and config where the config stays.
Do not create default share by default

Fixes #67

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-syncthing/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Add a dedicated directory `/data` to put shares inside it. Now /config is solely for configuration items.
Sync directory (the share share) is not created by default anymore. 

## Benefits of this PR and context:
Provide a dedicated place to create share, before that, creating would be only under `/config` which not ideal. 

## How Has This Been Tested?
1. I've installed the container on my server (x86_64) and run it using podman
2. I added the ID of the server to the instance running on my personal computer
3. I created a share ~/Music on my personal computer where all my music tunes are located
4. I added the server to the share
5. directory /data/Music was created on the container, and the synchronization started


## Source / References:
#67 
