### PR TITLE
Add configurable WebUI PORT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ LABEL maintainer="thelamer"
 
 # environment settings
 ENV HOME="/config"
+ENV PORT=8384
 
 RUN \
   echo "**** create var lib folder ****" && \
@@ -55,5 +56,5 @@ COPY --from=buildstage /tmp/sync/syncthing /usr/bin/
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
+EXPOSE ${PORT} 22000/tcp 22000/udp 21027/UDP
 VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -44,6 +44,7 @@ LABEL maintainer="thelamer"
 
 # environment settings
 ENV HOME="/config"
+ENV PORT=8384
 
 RUN \
   echo "**** create var lib folder ****" && \
@@ -55,5 +56,5 @@ COPY --from=buildstage /tmp/sync/syncthing /usr/bin/
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
+EXPOSE ${PORT} 22000/tcp 22000/udp 21027/UDP
 VOLUME /config

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -19,6 +19,8 @@ param_hostname_desc: "Optionally the hostname can be defined."
 param_usage_include_env: true
 param_env_vars:
   - {env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London."}
+opt_param_env_vars:
+  - {env_var: "PORT", env_value: "8384", desc: "Application WebUI listen Port" }
 param_usage_include_vols: true
 param_volumes:
   - {vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Configuration files."}
@@ -35,6 +37,7 @@ app_setup_block_enabled: true
 app_setup_block: "**Note: ** The Syncthing devs highly suggest setting a password for this container as it listens on 0.0.0.0. To do this go to `Actions -> Settings -> set user/password` for the webUI."
 # changelog
 changelogs:
+  - {date: "22.12.23:", desc: "Add configurable WebUI PORT" }
   - {date: "05.09.23:", desc: "Rebase to Alpine 3.18."}
   - {date: "01.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "13.02.23:", desc: "Rebase to Alpine 3.17, migrate to s6v3."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 
 exec \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8384" \
+    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${PORT}" \
         s6-setuidgid abc syncthing \
         -home=/config -no-browser -no-restart \
-        --gui-address="0.0.0.0:8384"
+        --gui-address="0.0.0.0:${PORT}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-syncthing/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Add optional configurable WebUI PORT.
## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
The current image cannot change the internal port of WebUI. This commit adds the PORT environment variable to avoid port conflicts that may be caused by hardcoded port when using the host network.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built an image from a Dockerfile and used it to create and run 2 containers simultaneously on the same host. Both Syncthing instances are successfully accessible through the GUI on the assigned ports, local discovery functions properly, and the instances are able to connect directly to other Syncthing instances on the local network.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
[FEAT] Add option to set listen address for GUI https://github.com/linuxserver/docker-syncthing/issues/65