### PR TITLE
Update README.md to clarify data-mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
 | `-v /config` | Configuration files. |
-| `-v /data1` | Data1 |
-| `-v /data2` | Data2 |
+| `-v /data1` | Example mount that mounts data into an arbitrary container-path. Use this path when configuring folders in the SyncThing UI |
+| `-v /data2` | Another example mount using an arbitrary container-path. Use this path when configuring folders in the SyncThing UI |
 
 ## Environment variables from files (Docker secrets)
 


### PR DESCRIPTION
clarify the intent of the data-mounts that are provided as examples

> If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  

Hope this PR is so low-effort in reviewing & merging that it can be integrated despite the closed issue: https://github.com/linuxserver/docker-syncthing/issues/57

There are quite a few questions around this when googling/perplexity'ing the internetz, so I guess a bit of clarification in the documentation is beneficial.

Thanks for the great containers