### PR TITLE
fix: use double-dash long options for syncthing v2.0.0

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -72,6 +72,7 @@ init_diagram: |
   "syncthing:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "08.13.25:", desc: "Use double-dash long options for syncthing v2.0.0."}
   - {date: "12.03.24:", desc: "Rebase to Alpine 3.21."}
   - {date: "06.06.24:", desc: "Rebase to Alpine 3.20."}
   - {date: "05.03.24:", desc: "Rebase to Alpine 3.19."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
@@ -4,5 +4,5 @@
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8384" \
         s6-setuidgid abc syncthing \
-        -home=/config -no-browser -no-restart \
+        --home=/config --no-browser --no-restart \
         --gui-address="0.0.0.0:8384"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-syncthing/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
In [syncthing v2.0.0](https://github.com/syncthing/syncthing/releases/tag/v2.0.0), they have dropped old single-dash long options. The `-home` used in the original startup script will be treated as `-h -o -m -e`, causing service start failure.

> Modernised command line options parsing. Old single-dash long options are
> no longer supported, e.g. -home must be given as --home. Some options
> have been renamed, others have become subcommands. All serve options are
> now also accepted as environment variables. See syncthing --help and
> syncthing serve --help for details.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR changed old single-dash long options to double-dash ones.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've ran `docker build -t ngc7331/syncthing --no-cache --pull .` and `docker run --name=syncthing-test -d -p 8385:8384 ngc7331/syncthing`. Access through webui and it works well for me.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
- https://github.com/syncthing/syncthing/releases/tag/v2.0.0