### PR TITLE
[Feat] Allow override of GUI's listen address from Syncthing configuration file or environs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,5 +56,5 @@ COPY --from=buildstage /tmp/sync/syncthing /usr/bin/
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
+EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -56,5 +56,5 @@ COPY --from=buildstage /tmp/sync/syncthing /usr/bin/
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8384 22000/tcp 22000/udp 21027/UDP
+EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 VOLUME /config

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
+      - STGUIADDRESS="0.0.0.0:8384" # optional
+      - STGUIHOST=0.0.0.0 # optional
+      - STGUIPORT=8384 # optional
     volumes:
       - /path/to/syncthing/config:/config
       - /path/to/data1:/data1
@@ -99,6 +102,9 @@ docker run -d \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Etc/UTC \
+  -e STGUIADDRESS="0.0.0.0:8384" `#optional` \
+  -e STGUIHOST=0.0.0.0 `#optional` \
+  -e STGUIPORT=8384 `#optional` \
   -p 8384:8384 \
   -p 22000:22000/tcp \
   -p 22000:22000/udp \
@@ -121,9 +127,12 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-p 22000:22000/tcp` | Listening port (TCP) |
 | `-p 22000:22000/udp` | Listening port (UDP) |
 | `-p 21027:21027/udp` | Protocol discovery |
-| `-e PUID=1000` | for UserID - see below for explanation |
-| `-e PGID=1000` | for GroupID - see below for explanation |
-| `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
+| `-e PUID=1000` | For UserID - see below for explanation |
+| `-e PGID=1000` | For GroupID - see below for explanation |
+| `-e TZ=Etc/UTC` | Specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
+| `-e STGUIADDRESS=0.0.0.0:8384` | Specify the application WebUI service listening address (default to `0.0.0.0:8384` if not overrided by env nor config.xml). Priority: env.STGUIADDRESS -> env.STGUIHOST/env.STGUIPORT -> config.xml -> default. |
+| `-e STGUIHOST=0.0.0.0` | Specify the application WebUI service listening host (default to `0.0.0.0` if not overrided by env nor config.xml). Priority: env.STGUIADDRESS -> env.STGUIHOST/env.STGUIPORT -> config.xml -> default. |
+| `-e STGUIPORT=8384` | Specify the application WebUI service listening port (default to `8384` if not overrided by env nor config.xml). Priority: env.STGUIADDRESS -> env.STGUIHOST/env.STGUIPORT -> config.xml -> default. |
 | `-v /config` | Configuration files. |
 | `-v /data1` | Data1 |
 | `-v /data2` | Data2 |
@@ -289,7 +298,7 @@ docker run --rm --privileged lscr.io/linuxserver/qemu-static --reset
 Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
 
 ## Versions
-
+* **06.12.25:** - [Feat] Allow override of GUI's listen address from Syncthing configuration file or environs
 * **16.08.25:** - Rebase to Alpine 3.22.
 * **13.08.25:** - Use double-dash long options for syncthing v2.0.0.
 * **03.12.24:** - Rebase to Alpine 3.21.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -13,6 +13,10 @@ available_architectures:
   - {arch: "{{ arch_arm64 }}", tag: "arm64v8-latest"}
 # container parameters
 common_param_env_vars_enabled: true #PGID, PUID, etc, you can set it to 'optional'
+params_environs: 
+  - { environ: "STGUIADDRESS", optional: true, desc: "Override default (0.0.0.0:8384) or STGUIHOST/STGUIPORT or confix.xml application Web UI listen address. Priority: env.STGUIADDRESS -> env.STGUIHOST/env.STGUIPORT -> config.xml -> default."}
+  - { environ: "STGUIHOST", optional: true, desc: "Override default (0.0.0.0) or config.xml application Web UI service listen host. Priority: env.STGUIADDRESS -> env.STGUIHOST/env.STGUIPORT -> config.xml -> default."}
+  - { environ: "STGUIPORT", optional: true, desc: "Override default (8384) or config.xml application Web UI service listen port. Priority: env.STGUIADDRESS -> env.STGUIHOST/env.STGUIPORT -> config.xml -> default."}
 param_container_name: "{{ project_name }}"
 param_usage_include_hostname: 'optional' #you can set it to 'optional'
 param_hostname: "{{ project_name }}"
@@ -72,6 +76,7 @@ init_diagram: |
   "syncthing:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "06.12.25:", desc: "[Feat] Allow override of GUI's listen address from Syncthing configuration file or environs"}
   - {date: "16.08.25:", desc: "Rebase to Alpine 3.22."}
   - {date: "13.08.25:", desc: "Use double-dash long options for syncthing v2.0.0."}
   - {date: "03.12.24:", desc: "Rebase to Alpine 3.21."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-syncthing/run
@@ -1,8 +1,45 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+# Listen address lookup from:
+#  1. Environ
+#    - 1. STGUIADDRESS
+#    - 2. STGUIHOST and/or STGUIPORT
+#  2. Config (config.xml)
+#  3. Default (0.0.0.0:8384)
+
+cfg_address=$(
+  awk -v lookup=0 '
+    $1 == "<gui"     { lookup=1 }
+    $1 == "</gui>"   { lookup=0 }
+    lookup == 1      { print }
+  ' /config/config.xml 2>/dev/null \
+  | grep address \
+  | sed 's|</\?address>||g; s|[[:space:]]||g'
+)
+
+cfg_host="${cfg_address%%:*}"
+cfg_port="${cfg_address##*:}"
+
+gui_address_host="${STGUIADDRESS%%:*}"
+gui_address_port="${STGUIADDRESS##*:}"
+
+gui_host="${STGUIHOST:-$cfg_host}"
+gui_port="${STGUIPORT:-$cfg_port}"
+
+gui_host="${gui_address_host:-$gui_host}"
+gui_port="${gui_address_port:-$gui_port}"
+
+gui_host="${gui_host:-0.0.0.0}"
+gui_port="${gui_port:-8384}"
+
+liveliness_target_host=$gui_host
+if [[ "x${gui_host}" == "x0.0.0.0" ]]; then
+  liveliness_target_host="127.0.0.1"
+fi
+
 exec \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8384" \
+    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z ${liveliness_target_host} ${gui_port}" \
         s6-setuidgid abc syncthing \
         --home=/config --no-browser --no-restart \
-        --gui-address="0.0.0.0:8384"
+        --gui-address="${gui_host}:${gui_port}"


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-syncthing/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This PR replaces the hardcoded default GUI listen address `--gui-address=0.0.0.0:8384` with a lookup sequence:

1. Environment variables lookup
    - a. From `STGUIADDRESS` (eg: `0.0.0.0:4242`)
    - b. From `STGUIHOST` (eg: `0.0.0.0`) and/or STGUIPORT (eg: `4242`)
2. Static configuration lookup from Syncthing config.xml
3. Default to `0.0.0.0` and `8384`

## Benefits of this PR and context:
After updating the container to the latest version, it was no longer possible to override the `--gui-address=0.0.0.0:8384` command argument during initialization, which broke my deployment setup. 
This PR introduces a flexible mechanism to control the GUI listening host and port, which is useful for deployments with race conditions or setups requiring custom configuration of the GUI endpoint.

## How Has This Been Tested?
- Built the image locally:  
  ```sh
  docker build --no-cache --pull -t lscr.io/linuxserver/syncthing:latest .
  ```
- Verified:
   - Starting a new built container, without previous configuration defaults to `0.0.0.0:8384`
   - Updating `config.xml` to change `gui.address`, then restarting the container correctly applies the configured values
       - `<address>127.0.0.1:4242</address>` -> `--gui-address=127.0.0.1:4242`
       - `<adress>:4242<address>` -> `--gui-address=0.0.0.0:4242`
       - `<address> :80    </address>` -> `--gui-address=0.0.0.0:80`
   - Setting the environment variable STGUIHOST overrides the address
   - Setting the environment variable STGUIPORT overrides the port

This PR introduces no breaking changes.

## Source / References:
- N/A
